### PR TITLE
fix: メインコンテンツエリア(記事を表示する箇所)のスクロールが効いていなかったため修正

### DIFF
--- a/app/(main)/[...slug]/page.tsx
+++ b/app/(main)/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { getDocument } from "@/lib/markdown"
 import { Settings } from "@/lib/meta"
 import { PageRoutes } from "@/lib/pageroutes"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Typography } from "@/components/ui/typography"
 import { BackToTop } from "@/components/navigation/backtotop"
@@ -25,27 +26,25 @@ export default async function Pages({ params }: PageProps) {
   const { frontmatter, content, tocs } = res
 
   return (
-    <>
-      <div className="flex items-start gap-14">
-        <section className="flex-[3]">
-          <PageBreadcrumb paths={slug} />
+    <div className="flex items-start gap-14">
+      <section className="flex-[3] pr-4">
+        <PageBreadcrumb paths={slug} />
 
-          <Typography>
-            <h1 className="!mb-2 text-3xl !font-semibold">
-              {frontmatter.title}
-            </h1>
-            <p className="-mt-4 text-sm">{frontmatter.description}</p>
-            <Separator className="my-6" />
-            <section>{content}</section>
-            <Pagination pathname={pathName} />
-          </Typography>
-        </section>
+        <Typography>
+          <h1 className="!mb-2 text-3xl !font-semibold">{frontmatter.title}</h1>
+          <p className="-mt-4 text-sm">{frontmatter.description}</p>
+          <Separator className="my-6" />
+          <section>{content}</section>
+          <Pagination pathname={pathName} />
+        </Typography>
+      </section>
 
-        {Settings.rightbar && (
-          <aside
-            className="toc sticky top-16 hidden h-[94.5vh] min-w-[230px] gap-3 py-8 xl:flex xl:flex-col"
-            aria-label="Table of contents"
-          >
+      {Settings.rightbar && (
+        <aside
+          className="toc sticky top-0 hidden h-full min-w-[230px] gap-3 py-8 xl:flex xl:flex-col"
+          aria-label="Table of contents"
+        >
+          <ScrollArea className="h-full">
             {Settings.toc && <Toc tocs={tocs} />}
             {Settings.feedback && (
               <Feedback slug={pathName} title={frontmatter.title} />
@@ -53,10 +52,10 @@ export default async function Pages({ params }: PageProps) {
             {Settings.totop && (
               <BackToTop className="mt-6 self-start text-sm text-neutral-800 dark:text-neutral-300/85" />
             )}
-          </aside>
-        )}
-      </div>
-    </>
+          </ScrollArea>
+        </aside>
+      )}
+    </div>
   )
 }
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -6,9 +6,9 @@ export default function Documents({
   children: React.ReactNode
 }>) {
   return (
-    <div className="flex items-start gap-10">
+    <div className="flex h-full items-start gap-10">
       <Sidebar />
-      <div className="flex-1 md:flex-[6]">{children}</div>{" "}
+      <div className="flex-1 overflow-auto md:flex-[6]">{children}</div>
     </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,17 +53,17 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className="h-full overflow-hidden">
       {Settings.gtmconnected && <GoogleTagManager gtmId={Settings.gtm} />}
-      <body
-        className={`${inter.variable} font-regular flex h-screen flex-col overflow-hidden`}
-      >
+      <body className={`${inter.variable} font-regular h-full overflow-hidden`}>
         <Providers>
-          <Navbar />
-          <main className="flex-1 overflow-hidden px-5 sm:px-8">
-            {children}
-          </main>
-          <Footer />
+          <div className="flex h-full flex-col">
+            <Navbar />
+            <main className="flex-1 overflow-auto px-5 sm:px-8">
+              {children}
+            </main>
+            <Footer />
+          </div>
         </Providers>
       </body>
     </html>

--- a/components/navigation/sidebar.tsx
+++ b/components/navigation/sidebar.tsx
@@ -17,10 +17,10 @@ import PageMenu from "@/components/navigation/pagemenu"
 export function Sidebar() {
   return (
     <aside
-      className="sticky top-16 hidden h-[94.5vh] min-w-[230px] flex-[1] flex-col overflow-y-auto md:flex"
+      className="sticky top-0 hidden h-full min-w-[230px] flex-[1] flex-col md:flex"
       aria-label="Page navigation"
     >
-      <ScrollArea className="py-4">
+      <ScrollArea className="h-full py-4">
         <PageMenu />
       </ScrollArea>
     </aside>


### PR DESCRIPTION
- オーバースクロール(バウンドされるようにページが引っ張られる挙動)も発生しないように修正
- 今後、左サイドバー(メニュー)
/メインコンテンツエリア/右サイドバー(目次)はスクロールを独立させる
- スクロールに関する修正は今後も続くと思うので、ブランチ名にインデックス(今回は`1`)を付与している